### PR TITLE
Sysctl bug fix and some docs improvements

### DIFF
--- a/hardening-script.sh
+++ b/hardening-script.sh
@@ -114,7 +114,7 @@ detect_package_manager
 
 # Lines to add to sysctl configuration
 sysctl_lines="
-# Kernel security
+## Kernel security
 kernel.kptr_restrict=2
 kernel.dmesg_restrict=1
 kernel.printk=3 3 3 3
@@ -125,7 +125,7 @@ vm.unprivileged_userfaultfd=0
 kernel.kexec_load_disabled=1
 kernel.sysrq=4
 
-# Network security
+## Network security
 net.ipv4.tcp_syncookies=1
 net.ipv4.tcp_rfc1337=1
 net.ipv4.conf.all.rp_filter=1
@@ -145,7 +145,7 @@ net.ipv4.tcp_sack=0
 net.ipv4.tcp_dsack=0
 net.ipv4.tcp_fack=0
 
-# Userspace security
+## Userspace security
 kernel.yama.ptrace_scope=2
 fs.protected_fifos=2
 fs.protected_regular=2

--- a/hardening-script.sh
+++ b/hardening-script.sh
@@ -114,6 +114,10 @@ detect_package_manager
 
 # Lines to add to sysctl configuration
 sysctl_lines="
+#################################################################### 
+## Security configs from Turtlecute33/Hardening-linux-script
+## Source: https://github.com/Turtlecute33/Hardening-linux-script
+
 ## Kernel security
 kernel.kptr_restrict=2
 kernel.dmesg_restrict=1
@@ -149,6 +153,8 @@ net.ipv4.tcp_fack=0
 kernel.yama.ptrace_scope=2
 fs.protected_fifos=2
 fs.protected_regular=2
+
+## End of security configs from Turtlecute33/Hardening-linux-script
 "
 
 # Apply sysctl settings


### PR DESCRIPTION
## [FIX: Add one more '#'](https://github.com/Turtlecute33/Hardening-linux-script/commit/4edb0f75f1b4f8d52efa502a49f7a4a3e7a2e301)
All the comments in the `sysctl_lines` become invalid instructions after removing leading '#' and whitespace.

```txt
# Kernel security
...
# Network security
...
# Userspace security
```
become
```txt
Kernel security
...
Network security
...
Userspace security
```
in the `/etc/sysctl.conf` file after [line 37](https://github.com/Turtlecute33/Hardening-linux-script/blob/68280f0f12922df8639c93c7f83d84e11e88ffa5/hardening-script.sh#L37)
```bash
line=$(echo "$line" | sed 's/^\s*#\s*//')  # Remove leading '#' and whitespace
```
These invalid instructions cause invalid application of kernel variables and a fail in the startup of `systemctl`. It's possibile to check these errors with `journalctl -u systemd-sysctl.service`. 

## [DOCS: add source comment in config file](https://github.com/Turtlecute33/Hardening-linux-script/commit/ed3811137db713cb1b0b7f6065718a7b991f1eb7)
I think it is always useful to have the source of the various configurations next to them. This can be useful for remembering in the future where certain configurations are coming from and maybe going to check for updates.